### PR TITLE
Improved use of file size limit

### DIFF
--- a/flickrsmartsync/remote.py
+++ b/flickrsmartsync/remote.py
@@ -143,7 +143,7 @@ class Remote(object):
         self.photo_sets_map = {}
 
         while True:
-            logger.info('Getting photosets page %s' % page)
+            logger.debug('Getting photosets page %s' % page)
             photosets_args.update({'page': page, 'per_page': 500})
             sets = json.loads(self.api.photosets_getList(**photosets_args))
             page += 1


### PR DESCRIPTION
Hi,

I just used the different file size limits for videos et images, and also tested it during the "sync" operation (useful to backup from different collections). 

I also changed the verbosity level of "nothing to do here" to debug to keep the logs with only infos about what was actually processed.

The change in verbosity level in remote.py is really minor, it's just that I don't think it adds useful info to the user, and since I append flickrsmartsync's output to a log on my server I end up with a collection of just these messages if I don't add any images for a few days (daily sync)