### PR TITLE
Add --fix-missing-description option

### DIFF
--- a/flickrsmartsync/__init__.py
+++ b/flickrsmartsync/__init__.py
@@ -35,6 +35,8 @@ def main():
                         help='ignore image files')
     parser.add_argument('--ignore-ext', type=str, 
                         help='comma separated list of extensions to ignore, e.g. "jpg,png"')
+    parser.add_argument('--fix-missing-description', action='store_true',
+                        help='given a missing set description, replaces it with set title')
     parser.add_argument('--version', action='store_true', 
                         help='output current version: ' + version)
     parser.add_argument('--sync-path', type=str, default=os.getcwd(),

--- a/flickrsmartsync/remote.py
+++ b/flickrsmartsync/remote.py
@@ -154,6 +154,21 @@ class Remote(object):
                 # Make sure it's the one from backup format
                 desc = html_parser.unescape(current_set['description']['_content'])
                 desc = desc.encode('utf-8') if isinstance(desc, unicode) else desc
+
+                if self.cmd_args.fix_missing_description and not desc:
+                    current_set_title = html_parser.unescape(current_set['title']['_content'])
+                    current_set_title = current_set_title.encode('utf-8') if isinstance(current_set_title, unicode) else current_set_title
+                    description_update_args = self.args.copy()
+                    description_update_args.update({
+                        'photoset_id': current_set['id'],
+                        'title': current_set_title,
+                        'description': current_set_title
+                    })
+                    logger.info('Set has no description. Updating it to [%s]...' % current_set_title)
+                    json.loads(self.api.photosets_editMeta(**description_update_args))
+                    logger.info('done')
+                    desc = current_set_title
+
                 if desc:
                     self.photo_sets_map[desc] = current_set['id']
                     title = self.get_custom_set_title(self.cmd_args.sync_path + desc)


### PR DESCRIPTION
Photosets (albums) created in Flickr may have a blank description, causing `flickrsmartsync --download` to ignore them. The `--fix-missing-description` option added in this PR works around the issue by filling in missing *description* values with *title*.